### PR TITLE
Support Babel6 transpiled ES6 modules

### DIFF
--- a/lib/Resolver.js
+++ b/lib/Resolver.js
@@ -8,6 +8,21 @@ var _ = require('lodash'),
 var SCATTER_FILE_NAME = 'particle.json';
 var DEFAULT_EXCLUDE = ['**/.*', 'node_modules'];
 
+/**
+ * Extended require to support loading Babel6 transpiled ES6 modules, which have their default export under the
+ * "default" key
+ */
+function requireExtended(name) {
+  var module = require(name);
+  if (module && module.__esModule === true && typeof module.default !== 'undefined') {
+    if (typeof module.__module !== 'undefined') {
+      // if __module is specified as a named export, add it to the default export
+      _.defaults(module.default, {__module: module.__module})
+    }
+    return module.default;
+  }
+  return module;
+};
 
 function Resolver(options) {
   this.particles = {};
@@ -197,7 +212,7 @@ Resolver.prototype.resolveModule = function(name, overrideComponent) {
         overrideFound = overrideComponent.descriptor.name === particle.descriptor.name;
       } else {
         mod = {
-          rawModule: require(fullpath),
+          rawModule: requireExtended(fullpath),
           particle: particle
         };
         return true;
@@ -256,7 +271,7 @@ Resolver.prototype.resolveAllInParticle = function(particle, subpath) {
         if(path.extname(fullPath) === ".js") {
           var modName = subpath.substring(0, subpath.lastIndexOf('.js')).replace(/\\/g, '/');
           modules[modName] = {
-            rawModule: require(fullPath),
+            rawModule: requireExtended(fullPath),
             particle: particle
           };
         }

--- a/test/01-load.js
+++ b/test/01-load.js
@@ -45,6 +45,15 @@ describe('Scatter basic loading', function() {
         done();
       }).catch(done);
     });
+
+    it('should accept ES6 modules transpiled by Babel6', function(done) {
+      scatter.load('ModuleES6').then(function(mod) {
+        expect(mod).to.exist;
+        expect(mod).to.have.property('prop', 'mod1');
+        done();
+      }).catch(done);
+    });
+
   });
 
 
@@ -125,7 +134,7 @@ describe('Scatter basic loading', function() {
         done();
       }).catch(done);
     });
-    
+
     it('should inject modules in constructor', function(done) {
       scatter.load('modules/RequireConstr').then(function(mod) {
         expect(mod).to.have.deep.property('dep.prop', 'depFactory');
@@ -160,6 +169,13 @@ describe('Scatter basic loading', function() {
         done(new Error("Exception not thrown"));
       }).catch(function(err) {
         expect(err).to.match(/Can't require a dynamic module from a static container/);
+        done();
+      }).catch(done);
+    });
+
+    it('should inject ES6 modules in ES6 module', function(done) {
+      scatter.load('modules/RequireFactoryES6').then(function(mod) {
+        expect(mod).to.have.deep.property('dep.prop', 'depObj');
         done();
       }).catch(done);
     });

--- a/test/01-load/basic/ModuleES6.js
+++ b/test/01-load/basic/ModuleES6.js
@@ -1,0 +1,8 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = {
+  prop: "mod1"
+};

--- a/test/01-load/di/anamespace/DepObjES6.js
+++ b/test/01-load/di/anamespace/DepObjES6.js
@@ -1,0 +1,8 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = {
+  prop: 'depObj'
+}

--- a/test/01-load/di/modules/RequireFactoryES6.js
+++ b/test/01-load/di/modules/RequireFactoryES6.js
@@ -1,0 +1,18 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = function(depObj) {
+  return {
+    prop: "requireFactory",
+    dep: depObj
+  };
+};
+
+exports["__module"] = {
+  bootstrapMode: 'factory',
+  args: ['anamespace/DepObjES6']
+};
+
+

--- a/test/01-load/nodeModulesLink/base2
+++ b/test/01-load/nodeModulesLink/base2
@@ -1,1 +1,1 @@
-/home/mario/dev/opensource-workspace/scatter/test/01-load//nodeModules/base2
+/Users/simonihmig/Projects/scatter/test/01-load//nodeModules/base2


### PR DESCRIPTION
When using ES6 modules transpiled by Babel6, the default export (POJO, factory, constructor) is under the "default" key, so Scatter is not able to correctly instantiate. This fixes it by detecting transpiled ES6 modules and loading the "default" export.
