### PR TITLE
Support instantiating ES6 classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "4.1"
   - "0.11"
   - "0.10"
   - "0.8"

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,20 +3,10 @@ var _ = require('lodash');
 var utils = module.exports = {};
 
 utils.applyConstruct = function(clazz, args) {
-  var obj, newobj;
-  function TmpClazz() {
-  }
-  TmpClazz.prototype = clazz.prototype;
-  obj = new TmpClazz();
-  obj.constructor = clazz;
-  newobj = clazz.apply(obj, args);
-  //function constructor?
-  if (newobj !== null
-  && (typeof newobj === "object" || typeof newobj === "function")
-  ) {
-    obj = newobj;
-  }
-  return obj;
+  var _bind = Function.prototype.bind;
+  var _slice = Array.prototype.slice;
+
+  return new (_bind.apply(clazz, [null].concat(_slice.call(args))))();
 };
 
 utils.delegate = function(to, method) {

--- a/test/01-load.js
+++ b/test/01-load.js
@@ -139,8 +139,17 @@ describe('Scatter basic loading', function() {
         done();
       }).catch(done);
     });
-    
-    
+
+    // poor man's ES6 support detection
+    if ('function' === typeof Map) {
+      it('should inject modules in ES6 classes', function(done) {
+        scatter.load('modules/RequireClass').then(function(mod) {
+          expect(mod).to.have.deep.property('dep.prop', 'depFactory');
+          done();
+        }).catch(done);
+      });
+    }
+
     it('should inject modules in "initialize"', function(done) {
       scatter.load('modules/RequireOnInit').then(function(mod) {
         expect(mod).to.have.deep.property('dep.prop', 'depFactory');

--- a/test/01-load/di/modules/RequireClass.js
+++ b/test/01-load/di/modules/RequireClass.js
@@ -1,0 +1,15 @@
+"use strict";
+
+class clazz {
+  constructor(depFactory) {
+    this.prop = "requireClass";
+    this.dep = depFactory;
+  }
+}
+
+module.exports = clazz;
+
+module.exports.__module = {
+  type: 'constructor',
+  args: ['DepFactory']
+};

--- a/test/01-load/nodeModulesLink/base2
+++ b/test/01-load/nodeModulesLink/base2
@@ -1,1 +1,1 @@
-/home/mario/dev/opensource-workspace/scatter/test/01-load//nodeModules/base2
+/Users/simonihmig/Projects/scatter/test/01-load//nodeModules/base2


### PR DESCRIPTION
When exporting a ES6 class (constructor), natively supported unter node.js 4.x/5.x, upon instantiation you get the exception "TypeError: Class constructors cannot be invoked without 'new'", because of the indirect instantiation in `utils.applyConstruct`. This fixes it by directly invoked the constructor with `new`.
